### PR TITLE
Handle haxe comments inside hxx

### DIFF
--- a/src/tink/hxx/Parser.hx
+++ b/src/tink/hxx/Parser.hx
@@ -98,9 +98,9 @@ class Parser extends ParserBase<Position, haxe.macro.Error> {
         e;
       #end
 
-  function parseExpr(source, pos) {
-    var posInfos = haxe.macro.PositionTools.getInfos(pos);
-    if (posInfos.min == posInfos.max) return macro @:pos(pos) {};
+  function parseExpr(source:String, pos) {
+    source = ~/\/\*.*?\*\//g.replace(source, '');
+    if (source.trim().length == 0) return macro @:pos(pos) null;
 
     return
       processExpr( 


### PR DESCRIPTION
Strips lines starting with `//` from hxx. This is especially useful when commenting out some nodes during development.

Drawback: some people might want a text node starting with `//` (?!), which is not possible any more.

So this:
```haxe
override public function render() {
	return jsx('
		<>
			<h2>My component</h2>
			// This is a comment, stripped by tink_hxx
			<p>This is a paragraph</p>
		</>
	');
}
```

Will render:
```html
<h2>My component</h2>
<p>This is a paragraph</p>
```