### PR TITLE
Handle empty expressions

### DIFF
--- a/src/tink/hxx/Parser.hx
+++ b/src/tink/hxx/Parser.hx
@@ -98,13 +98,17 @@ class Parser extends ParserBase<Position, haxe.macro.Error> {
         e;
       #end
 
-  function parseExpr(source, pos) 
+  function parseExpr(source, pos) {
+    var posInfos = haxe.macro.PositionTools.getInfos(pos);
+    if (posInfos.min == posInfos.max) return macro @:pos(pos) {};
+
     return
       processExpr( 
         try Context.parseInlineString(source, pos)
         catch (e:haxe.macro.Error) throw e
         catch (e:Dynamic) pos.error(e)
       );
+  }
 
   function simpleIdent() {
     var name = withPos(ident(true).sure());


### PR DESCRIPTION
Do not break (`MacroApi.Invalid_expr`) on `${}` or `{}`.
Should fix #12.