### PR TITLE
Allow comments in opening tags

### DIFF
--- a/src/tink/hxx/Parser.hx
+++ b/src/tink/hxx/Parser.hx
@@ -164,6 +164,11 @@ class Parser extends ParserBase<Position, haxe.macro.Error> {
         selfClosing = false;
 
     while (!allow('>')) {
+      if (allow('//')) {
+        upto('\n');
+        continue;
+      }
+
       if (allow('/')) {
         expect('>');
         selfClosing = true;


### PR DESCRIPTION
Allows adding comments or commenting out props inside opening tags in hxx, like in jsx:

```jsx
<MyComponent
  hello="world"
  foo="bar" // This is a comment
  // This is a comment too, and below attribute is commented out
  // bar="foo"
/>
```

Note: since it's looking for `\n`, I'm not 100% sure about ~~crappy~~ windows line endings...