### PR TITLE
Allow escaping '{' in hxx

### DIFF
--- a/src/tink/hxx/Parser.hx
+++ b/src/tink/hxx/Parser.hx
@@ -344,7 +344,9 @@ class Parser extends ParserBase<Position, haxe.macro.Error> {
 
     while (pos < max) {
 
-      switch first(["${", "$", "{", "<"], text) {
+      switch first(["\\{", "${", "$", "{", "<"], text) {
+        case Success("\\{"):
+          text("{");
         case Success("<"):
           if (allowHere('!--'))
             upto('-->', true).sure();


### PR DESCRIPTION
See #37

Note: this renders `value=\{Large}` as 3 different text nodes: `"variant="`, `"{"` and `"Large}"`