### PR TITLE
fix getCtor, fix typo in error message

### DIFF
--- a/src/tink/hxx/Tag.hx
+++ b/src/tink/hxx/Tag.hx
@@ -349,7 +349,8 @@ using StringTools;
           function getCtor()
             return
               if (isAbstract) cl.findField('_new', true);
-              else cl.constructor.get();
+              else if (cl.constructor != null) cl.constructor.get();
+              else throw '${cl.name} doesn\'t have a constructor ';
 
           function yield(f:ClassField, kind)
             return

--- a/src/tink/hxx/Tag.hx
+++ b/src/tink/hxx/Tag.hx
@@ -350,7 +350,7 @@ using StringTools;
             return
               if (isAbstract) cl.findField('_new', true);
               else if (cl.constructor != null) cl.constructor.get();
-              else throw '${cl.name} doesn\'t have a constructor ';
+              else null;
 
           function yield(f:ClassField, kind)
             return

--- a/src/tink/hxx/Tag.hx
+++ b/src/tink/hxx/Tag.hx
@@ -369,7 +369,7 @@ using StringTools;
                     if (cl.statics.get().length + cl.fields.get().length == 0)
                       'There seems to be a type error in $name that cannot be reported due to typing order. Please import the type explicitly or compile it separately.'
                     else
-                      'type $name does not define a suitable constructor of static fromHxx method to be used as HXX'
+                      'type $name does not define a suitable constructor or static fromHxx method to be used as HXX'
                   );
                 case v:
                   yield(v, New);


### PR DESCRIPTION
Report at least the name of the class that's missing the constructor. Maybe it should also ask if the hxx user forgot to extend coconut.ui.View?